### PR TITLE
BUGFIX/MINOR(promtail): fix `openio_bind_mgmt_address` typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An Ansible role for install promtail. Specifically, the responsibilities of this
 | :---       | :---    | :---             |
 | `openio_promtail_namespace` | `"{{ namespace \| d('OPENIO') }}"` | OpenIO Namespace |
 | `openio_promtail_maintenance_mode` | `"{{ openio_maintenance_mode \| d(false) }}"` | Maintenance mode |
-| `openio_promtail_bind_address` | `"{{ openio_mgmt_bind_address \| d(ansible_default_ipv4.address) }}"` | Binding IP address |
+| `openio_promtail_bind_address` | `"{{ openio_bind_mgmt_address \| d(ansible_default_ipv4.address) }}"` | Binding IP address |
 | `openio_promtail_bind_port` | `6900` | Binding port |
 | `openio_promtail_loki_group` | `"loki"`  | Lloki group in the inventory |
 | `openio_promtail_loki_port` | `6902` | Default port on which loki listens |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 openio_promtail_namespace: "{{ namespace | d('OPENIO') }}"
 openio_promtail_maintenance_mode: "{{ openio_maintenance_mode | d(false) }}"
 
-openio_promtail_bind_address: "{{ openio_mgmt_bind_address | d(ansible_default_ipv4.address) }}"
+openio_promtail_bind_address: "{{ openio_bind_mgmt_address | d(ansible_default_ipv4.address) }}"
 openio_promtail_bind_port: 6922
 
 openio_promtail_loki_group: "loki"

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -10,7 +10,7 @@ positions:
 {%   if groups[openio_promtail_loki_group] | length > 0 %}
 clients:
 {%     for host in groups[openio_promtail_loki_group] %}
-{%       set ip = hostvars[host].openio_loki_bind_address | d(hostvars[host].openio_mgmt_bind_address) | d(hostvars[host].ansible_default_ipv4.address)  %}
+{%       set ip = hostvars[host].openio_loki_bind_address | d(hostvars[host].openio_bind_mgmt_address) | d(hostvars[host].ansible_default_ipv4.address)  %}
 {%       set port = hostvars[host].openio_loki_bind_port | d(openio_promtail_loki_port)  %}
   - url: "http://{{ ip }}:{{ port }}/loki/api/v1/push"
 {%     endfor %}


### PR DESCRIPTION
 ##### SUMMARY
`openio_bind_mgmt_address` instead of `openio_mgmt_bind_address`

 ##### IMPACT
#Describe the impact of the change (N/A for no impact)
N/A

 ##### ADDITIONAL INFORMATION