### PR TITLE
CHANGE(promtail): remove `oio-` prefix to service_type

### DIFF
--- a/docker-tests/checks.bats
+++ b/docker-tests/checks.bats
@@ -24,13 +24,13 @@ run_only_test() {
 }
 
 @test 'Promtail config file exists' {
-  run bash -c "docker exec -ti ${SUT_ID} cat /etc/oio/sds/TRAVIS/oio-promtail-0/config.yml"
+  run bash -c "docker exec -ti ${SUT_ID} cat /etc/oio/sds/TRAVIS/promtail-0/config.yml"
   echo "output: "$output
   [[ "${status}" -eq "0" ]]
 }
 
 @test 'Promtail configuration file is valid YAML' {
-    run bash -c "docker exec -ti ${SUT_ID} find /etc/oio/sds/TRAVIS/oio-promtail-0/ -name \*.yml -exec python -c \
+    run bash -c "docker exec -ti ${SUT_ID} find /etc/oio/sds/TRAVIS/promtail-0/ -name \*.yml -exec python -c \
     'import sys,yaml; yaml.load(open(sys.argv[1]).read(), Loader=yaml.SafeLoader);' {} \;"
     echo "output: "$output
     [[ "${output}" -eq "" ]]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - include_role:
     name: openio-service
   vars:
-    openio_service_type: "oio-promtail"
+    openio_service_type: "promtail"
     openio_service_namespace: "{{ openio_promtail_namespace }}"
     openio_service_maintenance_mode: "{{ openio_promtail_maintenance_mode }}"
     openio_service_packages:


### PR DESCRIPTION
 ##### SUMMARY
no need to have `oio-` in front of service name for monitoring

 ##### IMPACT
service name and path changes

 ##### ADDITIONAL INFORMATION